### PR TITLE
Fix: instance variables & csv conversion

### DIFF
--- a/lib/game.rb
+++ b/lib/game.rb
@@ -8,16 +8,17 @@ class Game
                 :away_goals,
                 :home_goals,
                 :venue
-    def initialize(data_attributes)
-        @game_id = data_attributes[:game_id]
-        @season = data_attributes[:season]
-        @type = data_attributes[:type]
-        @date_time = data_attributes[:data_time]
-        @away_team_id = data_attributes[:away_team_id]
-        @home_team_id = data_attributes[:home_team_id]
-        @away_goals = data_attributes[:away_goals]
-        @home_goals = data_attributes[:home_goals]
-        @venue = data_attributes[:venue]
+
+    def initialize(game_id, season, type, date_time, away_team_id, home_team_id, away_goals, home_goals, venue)
+        @game_id = game_id.to_i
+        @season = season
+        @type = type
+        @date_time = data_time
+        @away_team_id = away_team_id.to_i
+        @home_team_id = home_team_id.to_i
+        @away_goals = away_goals.to_i
+        @home_goals = home_goals.to_i
+        @venue = venue
     end 
 
     def total_score

--- a/lib/game_team.rb
+++ b/lib/game_team.rb
@@ -1,0 +1,35 @@
+class GameTeam
+    attr_reader :game_id,
+                :team_id, 
+                :home_or_away_game, 
+                :result, 
+                :settled_in, 
+                :head_coach, 
+                :goals, 
+                :shots, 
+                :tackles, 
+                :pentalty_infraction_min, 
+                :power_play_opportunities, 
+                :power_play_goals, 
+                :face_off_win_percentage, 
+                :give_aways, 
+                :take_aways
+
+    def initialize(game_id, team_id, home_or_away_game, result, settled_in, head_coach, goals, shots, tackles, pentalty_infraction_min, power_play_opportunities, power_play_goals, face_off_win_percentage, give_aways, take_aways)
+        @game_id = game_id
+        @team_id = team_id
+        @home_or_away_game = home_or_away_game
+        @result = result
+        @settled_in = settled_in
+        @head_coach = head_coach
+        @goals = goals 
+        @shots = shots
+        @tackles = tackles
+        @pentalty_infraction_min = pentalty_infraction_min
+        @power_play_opportunities = power_play_opportunities
+        @power_play_goals = power_play_goals
+        @face_off_win_percentage = face_off_win_percentage
+        @give_aways = give_aways
+        @take_aways = take_aways
+    end
+end

--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -5,66 +5,71 @@ class StatTracker
                 :teams,
                 :game_teams
     
-    def initialize
-        @games = []
-        @teams = []
-        @game_teams = []
-    end
-
-    # class method for StatTracker
     def self.from_csv(locations)
-        #iterate through each hash key/value pair (key elements -> file_name, value elements -> file_path)
-        locations.each do |file_name, file_path|
-            
-            #for each hash value (file_path) goes through and converts the row to be another hash with the column headers as keys and the row values as the key's values.
-            CSV.foreach(file_path, headers: true, header_converters: :symbol) do |row|
-                if file_name == :games
-                    game_id = row[:game_id]
-                    season = row[:season]
-                    type = row[:type]
-                    date_time= row[:date_time]
-                    away_team_id = row[:away_team_id]
-                    home_team_id = row[:home_team_id]
-                    away_goals = row[:away_goals]
-                    home_goals = row[:home_goals]
-                    venue = row[:venue]
-                    game = Game.new(game_id, season, type, date_time, away_team_id, home_team_id, away_goals, home_goals, venue)
-                    @games << game
-                elsif file_name == :teams
-                    team_id = row[:team_id]
-                    franchise_id = row[:franchise]
-                    team_name = row[:teamName]
-                    abbreviation = row[:abbreviation]
-                    stadium = row[:stadium]
-                    @teams << team = Team.new(team_id, franchise_id, abbreviation, stadium)
-                elsif file_name == :game_teams
-                    game_id = row[:game_id]
-                    team_id = row[:team_id]
-                    home_or_away_game = row[:HoA]
-                    result = row[:res]
-                    settled_in = row[:settled_in]
-                    head_coach = row[:head_coach]
-                    goals = row[:goals]
-                    shots = row[:shots]
-                    tackles = row[:tackles]
-                    pentalty_infraction_min = row[:pim]
-                    power_play_opportunities = row[:powerPlayOpportunities]
-                    power_play_goals = row[:powerPlayGoals]
-                    face_off_win_percentage = row[:faceOffWinPercentage]
-                    give_aways = row[:giveaways]
-                    take_aways = row[:takeaway]
-                    game_team = GameTeam(game_id, team_id, home_or_away_game, result, settled_in, head_coach, goals, shots, tackles, pentalty_infraction_min, power_play_opportunities, power_play_goals, face_off_win_percentage, give_aways, take_aways)
-                    @game_teams << game_team
-                else
-                    puts "I don't have access to #{file_name}, sorry."
-                end
-            end
+        StatTracker.new(locations)
+    end
+    
+    def initialize(locations)
+        @games = games_csv_reader(locations[:games])
+        @teams = teams_csv_reader(locations[:teams])
+        @game_teams = game_teams_csv_reader(locations[:game_teams])
+    end
+                
+    def games_csv_reader(file_path)
+       games_array = []
+       CSV.readlines(file_path, headers: true, header_converters: :symbol).map do |row|
+            game_id = row[:game_id]
+            season = row[:season]
+            type = row[:type]
+            date_time= row[:date_time]
+            away_team_id = row[:away_team_id]
+            home_team_id = row[:home_team_id]
+            away_goals = row[:away_goals]
+            home_goals = row[:home_goals]
+            venue = row[:venue]
+            games_array << Game.new(game_id, season, type, date_time, away_team_id, home_team_id, away_goals, home_goals, venue)
         end
+        games_array
+    end
+    
+    def teams_csv_reader(file_path)
+        teams_array = []
+        CSV.readlines(file_path, headers: true, header_converters: :symbol).map do |row|
+            team_id = row[:team_id]
+            franchise_id = row[:franchiseid]
+            team_name = row[:teamname]
+            abbreviation = row[:abbreviation]
+            stadium = row[:stadium]
+            teams_array << Team.new(team_id, franchise_id, team_name, abbreviation, stadium)
+        end
+        teams_array
+    end
+    
+    def game_teams_csv_reader(file_path)
+        game_teams_array = []
+        CSV.readlines(file_path, headers: true, header_converters: :symbol).map do |row|
+            game_id = row[:game_id]
+            team_id = row[:team_id]
+            home_or_away_game = row[:hoa]
+            result = row[:res]
+            settled_in = row[:settled_in]
+            head_coach = row[:head_coach]
+            goals = row[:goals]
+            shots = row[:shots]
+            tackles = row[:tackles]
+            pentalty_infraction_min = row[:pim]
+            power_play_opportunities = row[:powerplayopportunities]
+            power_play_goals = row[:powerplaygoals]
+            face_off_win_percentage = row[:faceoffwinpercentage]
+            give_aways = row[:giveaways]
+            take_aways = row[:takeaways]
+            game_teams_array << GameTeam.new(game_id, team_id, home_or_away_game, result, settled_in, head_coach, goals, shots, tackles, pentalty_infraction_min, power_play_opportunities, power_play_goals, face_off_win_percentage, give_aways, take_aways)
+        end
+        game_teams_array
     end
 
     def highest_total_score
-        #.max may not be the correct method to call on games
-        @games.max {|game| game.total_score}
+        #code
     end
 
     def lowest_total_score

--- a/lib/team.rb
+++ b/lib/team.rb
@@ -5,16 +5,14 @@ class Team
               :abbreviation,
               :stadium
 
-  def initialize(attributes)
-    @team_id = attributes[:team_id]
-    @franchise_id = attributes[:franchise_id]
-    @team_name = attributes[:team_name]
-    @abbreviation = attributes[:abbreviation]
-    @stadium = attributes[:stadium]
+  def initialize(team_id, franchise_id, team_name, abbreviation, stadium)
+    @team_id = team_id
+    @franchise_id = franchise_id
+    @team_name = team_name
+    @abbreviation = abbreviation
+    @stadium = stadium
   end
-  
-=begin
-stat tracker is going to be the one to collect all the
-class of game shouldn't know anything about the class of teams
-
 end
+
+#stat tracker is going to be the one to collect all the
+#class of game shouldn't know anything about the class of teams

--- a/spec/game_spec.rb
+++ b/spec/game_spec.rb
@@ -2,7 +2,7 @@ require './spec/spec_helper'
 
 RSpec.describe Game do
     before(:each) do
-        @        game = Game.new({
+        @game = Game.new({
             :game_id => 2012030221, 
             :season => 20122013, 
             :type => "Postseason", 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,4 +6,5 @@ SimpleCov.start
 require './lib/stat_tracker'
 require './lib/game'
 require './lib/team'
+require './lib/game_team'
 

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -1,6 +1,6 @@
 require "./spec/spec_helper"
 
-Rspec.describe StatTracker do
+RSpec.describe StatTracker do
     it 'exists' do
         game_path = './data/games.csv'
         team_path = './data/teams.csv'
@@ -13,14 +13,15 @@ Rspec.describe StatTracker do
         }
 
         stat_tracker = StatTracker.new(locations)
-        expect(stat_tracker).to be_a(StatTracker)
+        expect(stat_tracker).to be_an_instance_of(StatTracker)
+        # expect(stat_tracker.game).to be_an_instance_of(Game)
     end
 
     it 'can create objects' do
         #code
     end
 
-    it 'exists' do
+    it 'highest total score game' do
         game_path = './spec/fixtures/games_fixture.csv'
         #this is looking at the original teams.csv file rn
         team_path = './data/teams.csv'
@@ -33,6 +34,7 @@ Rspec.describe StatTracker do
         }
 
         stat_tracker = StatTracker.new(locations)
-        expect(stat_tracker.highest_total_score).to be_a(5)
+        # StatTracker.from_csv(locations)
+        expect(stat_tracker.highest_total_score).to eq(5)
     end
 end


### PR DESCRIPTION
Fixed games, teams, and game_teams instance variables for StatTracker.
Changed how csv files' to use `readlines` instead of `foreach`.
Issue resolves #47 